### PR TITLE
Add start and stop actions

### DIFF
--- a/resources/winsw.rb
+++ b/resources/winsw.rb
@@ -82,6 +82,20 @@ class Chef
 
     end
 
+    action :start do
+      execute "#{new_resource.name} start" do
+        command "#{service_exec} start"
+        only_if "#{service_exec} status | find /i \"Stopped\""
+      end
+    end
+
+    action :stop do
+      execute "#{new_resource.name} stop" do
+        command "#{service_exec} stop"
+        only_if "#{service_exec} status | find /i \"Started\""
+      end
+    end
+
     action :restart do
 
       service_name = new_resource.service_name || new_resource.name


### PR DESCRIPTION
Thanks for creating this! It's been a huge help in a project I'm working on.

This adds `:start` and `:stop` actions. I found myself needing them in order to update a configuration file my service consumes. If the service is running the file cannot be removed. I need to notify the service to stop immediately, make the file changes, and then notify the service to start at the end of the run.