### PR TITLE
Allow custom winsw configuration via `options`

### DIFF
--- a/recipes/_winsw_spec_fixture.rb
+++ b/recipes/_winsw_spec_fixture.rb
@@ -4,5 +4,6 @@ node['winsw']['service'].each do |service_name, service_info|
     executable service_info['executable']
     args service_info['args']
     env_variables service_info['env_variables']
+    options service_info['options'] if service_info['options']
   end
 end

--- a/resources/winsw.rb
+++ b/resources/winsw.rb
@@ -11,6 +11,7 @@ class Chef
     property :executable, kind_of: String, required: true
     property :args, kind_of: Array, default: []
     property :env_variables, kind_of: Hash, default: {}
+    property :options, kind_of: Hash, default: {}
     property :supported_runtimes, kind_of: Array, default: %w( v2.0.50727 v4.0 )
 
     action :install do
@@ -59,7 +60,8 @@ class Chef
                       :service_name => "$#{service_name}",
                       :executable => new_resource.executable,
                       :arguments => new_resource.args,
-                      :env_vars => new_resource.env_variables
+                      :env_vars => new_resource.env_variables,
+                      :options => new_resource.options
                   })
         notifies :run, "execute[#{new_resource.name} restart]", :immediately
       end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -7,6 +7,7 @@ describe 'winsw::_winsw_spec_fixture' do
       node.set['winsw']['service']['test_service']['executable'] = 'test.exe'
       node.set['winsw']['service']['test_service']['args'] = ['arg0', 'arg1']
       node.set['winsw']['service']['test_service']['env_variables']['env0'] = 'env0 val'
+      node.set['winsw']['service']['test_service']['options']['stopparentprocessfirst'] = true
     end.converge(described_recipe)
   end
 
@@ -30,6 +31,7 @@ describe 'winsw::_winsw_spec_fixture' do
   <executable>test.exe</executable>
   <arguments>arg0 arg1</arguments>
   <logmode>rotate</logmode>
+  <stopparentprocessfirst>true</stopparentprocessfirst>
 </service>
     EOT
     expect(chef_run).to run_execute('test_service install')

--- a/templates/default/winsw.xml.erb
+++ b/templates/default/winsw.xml.erb
@@ -8,4 +8,7 @@
   <executable><%= @executable %></executable>
   <arguments><%= @arguments.join(' ') %></arguments>
   <logmode>rotate</logmode>
+  <% @options.each do |key, value| %>
+  <<%= key %>><%= value %></<%= key %>>
+  <% end %>
 </service>


### PR DESCRIPTION
Supports configuration of the various keys that winsw supports but are not explicitly linked to resource properties:

https://github.com/kohsuke/winsw/blob/master/doc/xmlConfigFile.md#configuration-entries